### PR TITLE
Fixes #46

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -33,7 +33,7 @@ class Team < ApplicationRecord
   end
 
   def dissolve(as_of)
-    return unless self.end_date.nil?
+    return unless self.end_date.nil? || (self.end_date > as_of)
     self.update_attribute(:end_date, as_of)
     stale_subs = self.submissions.joins(:assignment).where('due_date >= ?', as_of)
     stale_subs.update_all(stale_team: true)

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -1,7 +1,33 @@
 require 'test_helper'
 
 class TeamTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    make_standard_course
+    @jane = create(:user, name: "Jane von Classenstein", first_name: "Jane", last_name: "von Classenstein")
+    @jane_reg = create(:registration, course: @cs101, user: @jane, section_id: @section.crn)
+    @team = create(:team, course: @cs101, start_date: Date.today)
+    @team.users = [@jane, @john]
+    @team.save
+  end
+    
+  test "Dissolve team with nil end_date" do
+    assert @team.end_date.nil?
+    @when = DateTime.now
+    @team.dissolve(@when)
+    assert_equal @team.end_date, @when.to_date
+  end
+  test "Dissolve team with future end_date" do
+    @when = DateTime.now
+    @team.end_date = @when + 1.day
+    assert !@team.end_date.nil?
+    @team.dissolve(@when)
+    assert_equal @team.end_date, @when.to_date
+  end
+  test "Dissolve team with expired end_date" do
+    @when = DateTime.now
+    @team.end_date = @when - 1.day
+    assert !@team.end_date.nil?
+    @team.dissolve(@when)
+    assert_equal @team.end_date, @when.to_date - 1.day
+  end
 end


### PR DESCRIPTION
teams should be dissolvable if they either have no end date yet, or their end date is in the future of the dissolution date.