### PR TITLE
Enable a per-file post-processing pass when extracting output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ the setup process.
 sudo apt-get install build-essential git postgresql libpq-dev
 ```
 
+Some of the autograders require a synthetic X connection; for that,
+Bottlenose uses xvfb:
+
+```sh
+sudo apt-get install xvfb
+```
+
 ### Postgres
 
 ```sh
@@ -90,7 +97,7 @@ rails db:create
 rails db:migrate
 
 # Start delayed job worker.
-bin/delayed_job start
+bin/delayed_job start [-n #of workers]
 
 # Start the server
 rails s

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -4,13 +4,25 @@ require 'open3'
 
 module UploadsHelper
   class Postprocessor
-    def self.process(f)
-      if self.respond_to?(File.extname(f)[1..-1])
-        self.method(File.extname(f)[1..-1]).call(f)
-      end
+    private
+    PROCS = {}
+    public
+    def self.create_handler(name)
+      name = name.to_s
+      PROCS[name] = lambda 
+    end
+    def self.alias_handler(new_name, old_name)
+      new_name = new_name.to_s
+      old_name = old_name.to_s
+      PROCS[new_name] = PROCS[old_name]
     end
 
-    def self.rkt(f)
+    def self.process(f)
+      ext = File.extname(f)[1..-1]
+      PROCS[ext]&.call(f)
+    end
+
+    create_handler :rkt do |f|
       output, err, status = Open3.capture3("xvfb-run", "-a", "--server-num", "1",
                                            "racket", Rails.root.join("lib/assets/render-racket.rkt").to_s,
                                            "-o", f + "ext",
@@ -18,6 +30,7 @@ module UploadsHelper
       if status.success? || File.exists?(f + "ext")
         FileUtils.mv f + "ext", f
         Audit.log "Successfully processed #{f}"
+        return true
       else
         FileUtils.rm f + "ext", force: true
         Audit.log <<ERROR
@@ -28,8 +41,9 @@ Error: #{err}
 Output: #{output}
 ================================
 ERROR
+        return false
       end
     end
-    singleton_class.send(:alias_method, :ss, :rkt)
+    alias_handler :ss, :rkt
   end
 end

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -1,0 +1,35 @@
+require 'fileutils'
+require 'audit'
+require 'open3'
+
+module UploadsHelper
+  class Postprocessor
+    def self.process(f)
+      if self.respond_to?(File.extname(f)[1..-1])
+        self.method(File.extname(f)[1..-1]).call(f)
+      end
+    end
+
+    def self.rkt(f)
+      output, err, status = Open3.capture3("xvfb-run", "-a", "--server-num", "1",
+                                           "racket", Rails.root.join("lib/assets/render-racket.rkt").to_s,
+                                           "-o", f + "ext",
+                                           f)
+      if status.success? || File.exists?(f + "ext")
+        FileUtils.mv f + "ext", f
+        Audit.log "Successfully processed #{f}"
+      else
+        FileUtils.rm f + "ext", force: true
+        Audit.log <<ERROR
+================================
+Problem processing #{f}:
+Status: #{status}
+Error: #{err}
+Output: #{output}
+================================
+ERROR
+      end
+    end
+    singleton_class.send(:alias_method, :ss, :rkt)
+  end
+end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -5,6 +5,7 @@ require 'zlib'
 require 'find'
 
 class Upload < ApplicationRecord
+  include UploadsHelper
   validates :file_name,  :presence => true
   validates :user_id,    :presence => true
   validates :secret_key, :presence => true
@@ -135,13 +136,11 @@ class Upload < ApplicationRecord
     else
       FileUtils.cp(submission_path, extracted_path)
     end
-    # TODO (Ben):
-    # File.find(extracted_path) do |f|
-    #   if File.extname(f) == ".rkt" || File.extname(f) == ".ss"
-    #     contents = f.read
-    #     process contents with WXME postprocessor
-    #   end
-    # end
+    Find.find(extracted_path) do |f|
+      next unless File.file? f
+      next if File.extname(f).empty?
+      Postprocessor.process(f)
+    end
   end
 
   def upload_dir

--- a/lib/assets/render-racket.rkt
+++ b/lib/assets/render-racket.rkt
@@ -1,0 +1,84 @@
+#lang racket
+
+;(require wxme/private/readable-editor)
+(require file/convertible)
+(require net/base64)
+(require xml)
+
+(require racket/gui/base)
+(require framework)
+
+(define count 0)
+(define (encomment s)
+  (apply bytes-append
+         (map (lambda (s)
+                (bytes-append #";;; " s #"\n"))
+              (regexp-split #rx#"\n" s))))
+
+(define (display-all snip out)
+  (if (not snip)
+      out
+      (begin
+        (cond
+          [(is-a? snip string-snip%)
+           (display (send snip get-text 0 (send snip get-count)) out)]
+          [(is-a? snip comment-box:snip%)
+           (let* ((comment (open-output-bytes))
+                  (contents (display-all (send (send snip get-editor) find-first-snip) comment)))
+             (display (encomment (get-output-string contents)) out))]
+          [(equal? (send (send snip get-snipclass) get-classname)
+                   "(lib \"number-snip.ss\" \"drscheme\" \"private\")")
+           (display "#|Number widget|#" out)
+           (display (send snip get-number) out)
+           ]
+          [(equal? (send (send snip get-snipclass) get-classname)
+                   "(lib \"xml-snipclass.ss\" \"xml\")")
+           (display "#|XML|#" out)
+           (display-all (send (send snip get-editor) find-first-snip) out)
+           ]
+          [(equal? (send (send snip get-snipclass) get-classname)
+                   "(lib \"scheme-snipclass.ss\" \"xml\")")
+           (display "#|RACKET|#" out)
+           (if (send snip get-splice?)
+               (display ",@(" out)
+               (display ",(" out))
+           (display-all (send (send snip get-editor) find-first-snip) out)
+           (display ")" out)
+           ]
+          [(is-a? snip editor-snip%)
+           (display-all (send (send snip get-editor) find-first-snip) out)
+           ]
+          [(convertible? snip)
+           (let ((serial count))
+             (set! count (+ 1 count))
+             (display (format "~~embed:~a:s~~data:image/png;base64,~a~~embed:~a:e~~" serial (base64-encode (convert snip 'png-bytes) "") serial) out))]
+          [else
+           (display (format ">>>~a<<<" snip) out)]
+          )
+        (display-all (send snip next) out))))
+(define (render file)
+  (let* ((dummy (new text%))
+         (_ (send dummy load-file file))
+         (first (send dummy find-first-snip))
+         (text (get-output-string (display-all first (open-output-bytes))))
+         )
+    (apply bytes-append
+           (add-between (drop (regexp-split #rx#"\n" text) 3)
+                        #"\n"))))
+
+(define output-filename (make-parameter #f))
+
+(display (current-command-line-arguments))
+ 
+(define file-to-compile
+  (command-line
+   #:program "render-racket"
+   #:once-each [("-o") outfile
+                       "Output filename (optional)"
+                       (output-filename outfile)]
+   #:args (filename)
+   filename))
+(define rendered (render file-to-compile))
+(if (output-filename)
+    (with-output-to-file (output-filename) #:exists 'replace (λ() (display rendered)))
+    (display rendered))

--- a/lib/assets/render-racket.rkt
+++ b/lib/assets/render-racket.rkt
@@ -68,8 +68,6 @@
 
 (define output-filename (make-parameter #f))
 
-(display (current-command-line-arguments))
- 
 (define file-to-compile
   (command-line
    #:program "render-racket"


### PR DESCRIPTION
Currently, the only postprocessing being done is on Racket files (with .rkt and .ss extensions), but more can easily be added by defining appropriately named methods on UploadsHelper::Postprocessor.  The Racket postprocessing takes wxme-formatted files and transforms them into a pure-text format whose images are encoded as Base64 PNGs, which can then be rendered dynamically via JS and CodeMirror (see commit caeb06022d768c9828c58caa451af76735aa1fe9 in the old commit history).