### PR TITLE
Cleaned up index pages of Terms, Users, and Settings

### DIFF
--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -1,5 +1,9 @@
 <% @page_title = "Bottlenose Settings" %>
 
+<div class="page-header">
+  <h1>Settings</h1>
+</div>
+
 <%= form_tag :settings, method: :patch do %>
   <div class="form-group">
     <%= label_tag :site_email, "Site Email" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,11 +13,9 @@
 
 <% @users.each do |user| %>
   <tr>
-    <td><%= user.name %></td>
+    <td><%= link_to user.name, user_path(user)%></td>
     <td><%= user.email %></td>
-    <td><%= link_to 'Show', user_path(user) %></td>
-    <td><%= link_to 'Edit', edit_user_path(user) %></td>
-    <td><%= link_to 'Impersonate', impersonate_user_path(user), method: 'post' %></td>
+    <td><%= link_to 'Impersonate', impersonate_user_path(user), method: 'post', class: "btn btn-danger" %></td>
   </tr>
 <% end %>
 </table>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,7 +13,7 @@
 
 <% @users.each do |user| %>
   <tr>
-    <td><%= link_to user.name, user_path(user)%></td>
+    <td><%= link_to user.name, user_path(user) %></td>
     <td><%= user.email %></td>
     <td><%= link_to 'Impersonate', impersonate_user_path(user), method: 'post', class: "btn btn-danger" %></td>
   </tr>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 20170602143559) do
     t.integer "team_min"
     t.integer "team_max"
     t.integer "total_late_days"
-    t.integer "lateness_config_id", default: 0
+    t.integer "lateness_config_id", default: 0, null: false
   end
 
   create_table "delayed_jobs", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
 - Deleted show and edit button on Users index page. Click individual user name to get to the "Show" page, and Click "Edit Profile" to edit the user info.
![screen shot 2017-07-04 at 13 25 20](https://user-images.githubusercontent.com/15064985/27839026-5eecc03e-60bc-11e7-940a-4609344801fc.png)


![screen shot 2017-07-04 at 13 26 28](https://user-images.githubusercontent.com/15064985/27839034-6af97b10-60bc-11e7-9610-9ba8e2c48c3f.png)

- Added header for Settings/edit
![screen shot 2017-07-04 at 13 27 35](https://user-images.githubusercontent.com/15064985/27839055-90a02b98-60bc-11e7-94bf-3df3503e862e.png)
