### PR TITLE
Bugfix

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -71,6 +71,14 @@ class CoursesController < ApplicationController
     if @course.save
       redirect_to course_path(@course), notice: 'Course was successfully created.'
     else
+      new_course = @course.dup
+      new_course.lateness_config = @course.lateness_config.dup
+      new_course.sections = @course.sections.map(&:dup)
+      @course.errors.each do |attr, err|
+        new_course.errors[attr] << err
+      end
+      @course.destroy
+      @course = new_course
       render :new, layout: 'application'
     end
   end

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -57,6 +57,39 @@ class CoursesControllerTest < ActionController::TestCase
     assert_redirected_to course_path(assigns(:course))
   end
 
+  test "should create course where 1 prof teaches 2 sections" do
+    lateness = create(:lateness_config)
+
+    sign_in @ken
+    assert_difference('Course.count') do
+      post :create, params: {
+             course: {
+               name: "Worst Course Ever", 
+               term_id: @term.id,
+               sections_attributes: {
+                 "0" => {
+                   prof_name: @fred.username,
+                   crn: "999",
+                   meeting_time: "TBD",
+                 },
+                 "1" => {
+                   prof_name: @fred.username,
+                   crn: "888",
+                   meeting_time: "TBD",
+                 }
+               },
+               lateness_config_attributes: {
+                 type: "FixedDaysConfig",
+                 days_per_assignment: 1,
+               }
+             }
+           }
+    end
+
+    assert_redirected_to course_path(assigns(:course))
+  end
+
+  
   test "should show course" do
     sign_in @john
     get :show, params: {id: @course1}


### PR DESCRIPTION
If a professor teaches multiple sections while trying to create the course, course creation would fail.  This remedies that, fixes lost-data in the course-creation page, and adds a regression test to ensure it doesn't happen again.