### PR TITLE
Removing navbar (stop impersonating) from withdraw screenshots.

### DIFF
--- a/lib/tasks/screenshots.rb
+++ b/lib/tasks/screenshots.rb
@@ -1035,10 +1035,12 @@ class Screenshots
       yield
       visit(course_path(@course))
 
+      # NOTE: Whole page is not included since Stop Impersonating was in the navbar. More useful
+      # for student manual.
+      course_header = page.find(:xpath, ".//div[@class='page-header']")
       withdraw = page.find(:xpath, ".//button[contains(text(), 'Withdraw from this course')]")
       hilite = highlight_area("withdraw", bbox(withdraw))
-      set_full_page
-      yield
+      yield options: inflate_box(bbox(course_header, hilite), 10, 10, 10, 10)
       remove_highlight "withdraw"
       set_default_size
 
@@ -1048,8 +1050,13 @@ class Screenshots
       yield options: bbox(content)
       set_default_size
       page.find(:xpath, ".//a[contains(@href, 'withdraw')]").click
-      set_full_page
-      yield
+      # Withdrawal confirmation (success message and updated course info) are 
+      # the first two containers from the body tag.
+      withdraw_confirmation_container = 
+        page.find(:xpath, "//body/div[@class='container'][1]")
+      course_info_container = page.find(:xpath, "//body/div[@class='container'][2]")
+      yield options: inflate_box(bbox(withdraw_confirmation_container, course_info_container), 
+                                 5, 5, 5, 5)
       page.find(:xpath, ".//a[text()='Stop Impersonating']").click
       set_full_page
       yield

--- a/lib/tasks/screenshots.rb
+++ b/lib/tasks/screenshots.rb
@@ -1050,12 +1050,10 @@ class Screenshots
       yield options: bbox(content)
       set_default_size
       page.find(:xpath, ".//a[contains(@href, 'withdraw')]").click
-      # Withdrawal confirmation (success message and updated course info) are 
-      # the first two containers from the body tag.
-      withdraw_confirmation_container = 
-        page.find(:xpath, "//body/div[@class='container'][1]")
-      course_info_container = page.find(:xpath, "//body/div[@class='container'][2]")
-      yield options: inflate_box(bbox(withdraw_confirmation_container, course_info_container), 
+      withdraw_success_alert = 
+        page.find(:xpath, ".//div[contains(text(), 'You have successfully withdrawn from')]/../..")
+      course_info_container = page.find(:xpath, ".//h2[text()='Your courses']/..")
+      yield options: inflate_box(bbox(withdraw_success_alert, course_info_container), 
                                  5, 5, 5, 5)
       page.find(:xpath, ".//a[text()='Stop Impersonating']").click
       set_full_page


### PR DESCRIPTION
Moved over from blerner/bottlenose.

Basically removing the Stop Impersonating from withdraw from course manual screenshots so that they become useful for the Student guide.