### PR TITLE
Sort by date

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -195,7 +195,7 @@ $.tablesorter.addParser({
     return false;
   },
   format: function(_, _, cell, _) {
-    return $(cell).data("iso-date");
+    return $(cell).find("span.local-time").data("iso-date");
   },
   parsed: false,
   type: "text"

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -189,8 +189,22 @@ function activate_file_picker($e) {
   });
 }
 
+$.tablesorter.addParser({
+  id: 'dates',
+  is: function(_) {
+    return false;
+  },
+  format: function(_, _, cell, _) {
+    return $(cell).data("iso-date");
+  },
+  parsed: false,
+  type: "text"
+});
+
 $(function() {
   $('.local-time').each(function(_) {
+    $(this).data("iso-date", $(this).text());
+    console.log("Data: "+ $(this).data("iso-date"));
     $(this).text(makeFriendlyDate($(this).text(), true));
   });
   $(".local-time-title").each(function(_) {
@@ -203,7 +217,6 @@ $(function() {
       html: true
     });
   });
-
 
   $("input.numeric").on("keydown", validateNumericInput);
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -204,7 +204,6 @@ $.tablesorter.addParser({
 $(function() {
   $('.local-time').each(function(_) {
     $(this).data("iso-date", $(this).text());
-    console.log("Data: "+ $(this).data("iso-date"));
     $(this).text(makeFriendlyDate($(this).text(), true));
   });
   $(".local-time-title").each(function(_) {

--- a/app/views/assignments/_admin_subs.html.erb
+++ b/app/views/assignments/_admin_subs.html.erb
@@ -145,7 +145,7 @@
           <% end %>
           <%= toggle_usernames_button("show_username", "submissions") %>
         </th>
-        <th>Date</th>
+        <th class="sorter-dates">Date</th>
         <th>Status</th>
         <% @gradesheet.grades[:graders].each do |c| %>
         <th class="text-right">
@@ -213,7 +213,7 @@
         <td><%= maybe_link_user(current_user.site_admin? || cur_user_prof_ever || current_user.id == sub.user.id,
                                 sub.user) %></td>
         <% end %>
-        <td><span class="local-time"><%= sub.created_at.iso8601 %></span></td>
+        <td class="local-time"><span class="local-time"><%= sub.created_at.iso8601 %></span></td>
         <% scores = grade[:staff_scores] %>
         <td><%= status_image(sub, 100.0 * scores[:raw_score] / @gradesheet.max_score) %></td>
         <% scores[:scores].zip(grade[:grade_times]).each do |s, t| %>

--- a/app/views/assignments/_admin_subs.html.erb
+++ b/app/views/assignments/_admin_subs.html.erb
@@ -213,7 +213,7 @@
         <td><%= maybe_link_user(current_user.site_admin? || cur_user_prof_ever || current_user.id == sub.user.id,
                                 sub.user) %></td>
         <% end %>
-        <td class="local-time"><span class="local-time"><%= sub.created_at.iso8601 %></span></td>
+        <td><span class="local-time"><%= sub.created_at.iso8601 %></span></td>
         <% scores = grade[:staff_scores] %>
         <td><%= status_image(sub, 100.0 * scores[:raw_score] / @gradesheet.max_score) %></td>
         <% scores[:scores].zip(grade[:grade_times]).each do |s, t| %>

--- a/app/views/assignments/_table.html.erb
+++ b/app/views/assignments/_table.html.erb
@@ -11,7 +11,7 @@
     <thead>
       <tr>
         <th>Name</th>
-        <th>Due Date</th>
+        <th class="sorter-dates">Due Date</th>
         <% if show_weight %>
           <th>Weight</th>
         <% end %>

--- a/app/views/assignments/_user_subs.html.erb
+++ b/app/views/assignments/_user_subs.html.erb
@@ -18,7 +18,7 @@
       <% else %>
       <th>Submitter</th>
       <% end %>
-      <th>Date</th>
+      <th class="sorter-dates">Date</th>
       <th>Status</th>
       <% gradesheet.grades[:graders].each do |c| %>
       <th class="text-right"><%= c.display_type %></th>

--- a/app/views/assignments/audit_access.erb
+++ b/app/views/assignments/audit_access.erb
@@ -28,9 +28,9 @@
           Student
           <%= toggle_usernames_button("show_username", "submissions") %>
         </th>
-        <th>Earliest access date</th>
+        <th class="sorter-dates">Earliest access date</th>
         <th>Earliest submission</th>
-        <th>Most recent access date</th>
+        <th class="sorter-dates">Most recent access date</th>
         <th>Most recent submission</th>
       </tr>
     </thead>

--- a/app/views/assignments/audit_access.erb
+++ b/app/views/assignments/audit_access.erb
@@ -100,7 +100,11 @@
       $("#submissions").tablesorter({
         headerTemplate: "{content} {icon}",
         theme: "bootstrap",
-        widgets: ['uitheme']
+        widgets: ['uitheme'],
+        headers: {
+          2: { sorter: false },
+          4: { sorter: false }
+        }
       });
       $(".no-resort").on("mousedown", function(e) { e.stopPropagation(); });
       enableShowUsernames("#show_username");

--- a/app/views/assignments/index.html.erb
+++ b/app/views/assignments/index.html.erb
@@ -34,8 +34,8 @@
       <thead>
         <tr>
           <th>Assignment</th>
-          <th>Assigned</th>
-          <th>Due</th>
+          <th class="sorter-dates">Assigned</th>
+          <th class="sorter-dates">Due</th>
           <th>Weight</th>
           <th>Min (%)</th>
           <th>Avg (%)</th>

--- a/app/views/courses/_lateness_summary.html.erb
+++ b/app/views/courses/_lateness_summary.html.erb
@@ -26,7 +26,7 @@
         <thead>
           <tr>
             <th>Name</th>
-            <th>Submitted</th>
+            <th class="sorter-dates">Submitted</th>
             <th>Late Days Used</th>
           </tr>
         </thead>


### PR DESCRIPTION
This one should be all set. Based on #220: added a custom parser (`addParser`) for table sorter, and dates are now saved to spans with `data` function called with key/id `iso-date`. 

Screenshots for correct sorting on assignment page:

![dates-work-ascending](https://user-images.githubusercontent.com/33663414/152654068-83fca558-3e37-4898-b6df-e380fcca440b.PNG)

![dates-work-descending](https://user-images.githubusercontent.com/33663414/152654070-716ff4b3-d41d-4a41-9f14-95e0237d7970.PNG)

