### PR TITLE
Feature: Send Jobs to Orca

### DIFF
--- a/app/models/graders/dockerfiles/java_graders/74b320b733359ebfa19428c8f073de1a700b6883e84ca70d0f13858830a7b250.Dockerfile
+++ b/app/models/graders/dockerfiles/java_graders/74b320b733359ebfa19428c8f073de1a700b6883e84ca70d0f13858830a7b250.Dockerfile
@@ -1,0 +1,6 @@
+FROM orca-grader-base:latest
+
+RUN ["apt", "update"]
+RUN ["apt", "install", "openjdk-11-jdk-headless", "-y"]
+
+USER orca-grader

--- a/app/models/graders/file_processing/java_graders.rb
+++ b/app/models/graders/file_processing/java_graders.rb
@@ -1,0 +1,43 @@
+require 'fileutils'
+
+class JavaGraderFileProcessor
+
+  def self.process_zip(upload, grader)
+    grader_dir = upload.grader_dir(grader)
+    starter_zip_path, testing_zip_path = grader_dir.join("starter.zip"),
+                                          grader_dir.join("testing.zip")
+    # Since this method is run on a grader's :after_save hook, it's
+    # possible files may already exist and need to be cleaned up.
+    [starter_zip_path, testing_zip_path].each do |zip_path|
+      if File.exists?(zip_path)
+        FilUtils.rm(zip_path)
+      end
+    end
+    include_starter_zip = false
+    if Dir.exists?(grader_dir.join("starter")) && Dir.exists?(grader_dir.join("testing"))
+      self.populate_zip(starter_zip_path, grader_dir, "starter")
+      self.populate_zip(testing_zip_path, grader_dir, "testing")
+      include_starter_zip = true
+    else
+      self.populate_zip(testing_zip_path, grader_dir, "")
+    end
+    
+    zip_file_paths = { testing: testing_zip_path }
+    if include_starter_zip
+      zip_file_paths["starter"] = starter_zip_path
+    end
+  end
+
+  def self.populate_zip(zip_file_path, grader_dir, grader_contents_path)
+    Zip::File.open(zip_file_path, Zip::File::CREATE) do |zipfile|
+      Dir[File.join(grader_dir, grader_contents_path, "**", "**")] do |file|
+        path = Pathname.new(file)
+        zipfile.add(
+          path.relative_path_from(Pathname.join(grader_dir, grader_contents_path)),
+          file
+        )
+      end
+    end
+  end
+
+end

--- a/app/models/graders/junit_grader.rb
+++ b/app/models/graders/junit_grader.rb
@@ -94,7 +94,7 @@ class JunitGrader < Grader
       current_exponent++
     end
     if status_code != 200
-      raise OrcaJobCreationError.new()
+      raise OrcaJobCreationError.new(status_code)
     end
   end
 
@@ -364,7 +364,11 @@ class JunitGrader < Grader
   end
 
   class OrcaJobCreationError < StandardError
-    def initialize(msg="Could not send a job to Orca after multiple HTTP request retires.")
+
+    :attr_reader status_code
+
+    def initialize(status_code, msg="Could not send a job to Orca after multiple HTTP request retries.")
+      @status_code = status_code
       super
     end
   end

--- a/app/models/graders/junit_grader.rb
+++ b/app/models/graders/junit_grader.rb
@@ -104,7 +104,8 @@ class JunitGrader < Grader
     ans["files"] = self.generate_file_hash
     ans["collation"] = sub.team ? { id: sub.team.id, type: "team" } :
                         { id: sub.user.id, type: "user"}
-    ans["response_url"] = "#{Settings['site_url']}/job-output"
+    ans["response_url"] = "#{Settings['site_url']}/"\
+                          "#{orca_response_course_assignment_submission_grades(@assignment.course, @assignment, sub)}"
     ans["script"] = self.get_grading_script
     ans["grading_image_sha"] = @@dockerfile_sha
     ans["metadata"] = self.generate_grading_job_metadata_table(sub)

--- a/app/models/graders/scripts/junit_grader.json
+++ b/app/models/graders/scripts/junit_grader.json
@@ -1,0 +1,82 @@
+[
+  {
+    "condition": {
+      "predicate": "dir",
+      "path": "$EXTRACTED/starter"
+    },
+    "on_true": [
+      {
+        "cmd": ["cp", "-r", "$EXTRACTED/starter/src/.", "$BUILD/"]
+      },
+      {
+        "cmd": ["cp", "-r", "$EXTRACTED/starter/test/.", "$BUILD/"]
+      }
+    ]
+  },
+  {
+    "cmd": ["cp", "-r", "$EXTRACTED/submission/src/.", "$BUILD/"]
+  },
+  {
+    "cmd": ["cp", "-r", "$EXTRACTED/submission/test/.", "$BUILD/"]
+  },
+  {
+    "cmd": ["cp", "-r", "$EXTRACTED/junit-jar/*", "$BUILD/"]
+  },
+  {
+    "cmd": ["cp", "-r", "$EXTRACTED/hamcrest-jar/*", "$BUILD/"]
+  },
+  {
+    "cmd": ["cp", "-r", "$EXTRACTED/junit-tap-jar/*", "$BUILD/"]
+  },
+  {
+    "cmd": ["cp", "-r", "$EXTRACTED/annotations-jar/*", "$BUILD/"]
+  },
+  {
+    "condition": {
+      "predicate": "dir",
+      "path": "$EXTRACTED/testing"
+    },
+    "on_true": [
+      {
+        "cmd": ["cp", "-r", "$EXTRACTED/testing/src/.", "$BUILD/"]
+      },
+      {
+        "cmd": ["cp", "-r", "$EXTRACTED/testing/test/.", "$BUILD/"]
+      }
+    ]
+  },
+  {
+    "cmd": ["tree"],
+    "working_dir": "$BUILD"
+  },
+  {
+    "cmd": [
+      "find",
+      "-type",
+      "f",
+      "-name",
+      "'*.java'",
+      "-fprint",
+      "compile-list.txt"
+    ],
+    "working_dir": "$BUILD",
+    "label": "gen-compile-list"
+  },
+  {
+    "cmd": ["cat", "compile-list.txt"],
+    "working_dir": "$BUILD"
+  },
+  {
+    "cmd": [
+      "javac",
+      "-cp",
+      "junit-4.13.2.jar:junit-tap.jar:hamcrest-core-1.3.jar:annotations.jar:.:./*",
+      "@compile-list.txt"
+    ],
+    "working_dir": "$BUILD"
+  },
+  {
+    "cmd": ["tree"],
+    "working_dir": "$BUILD"
+  }
+]

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -4,6 +4,7 @@ class Settings
       "site_email"   => 'Bottlenose <noreply@example.com>',
       "backup_login" => '',
       "site_url"     => '',
+      "orca_url"     => ''
     }
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -500,7 +500,13 @@ class Submission < ApplicationRecord
     return sub_dirs, sub_files
   end
 
-
+  def priority
+    duration = 15.minutes
+    priority_base = 60 # seconds
+    priority_base * (self.team ? 
+      self.team.num_submissions_in_last_duration(self.created_at, duration) :
+      self.user.num_submissions_in_last_duration(self.created_at, duration))
+  end
 
   protected
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,8 +152,10 @@ Rails.application.routes.draw do
         resources :grades, only: [:show, :edit, :update] do
           member do
             post :regrade
-            post :orca_response
             get :details, defaults: {format: 'text'}
+          end
+          collection do
+            post :orca_response
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,6 +152,7 @@ Rails.application.routes.draw do
         resources :grades, only: [:show, :edit, :update] do
           member do
             post :regrade
+            post :orca_response
             get :details, defaults: {format: 'text'}
           end
         end


### PR DESCRIPTION
## Problem
Bottlenose should be able to send a job to Orca with the requisite execution information, priority, response information, and more. It should then be able to take in a response, verify it is coming from the correct source, and then record its output to be compared to its current output later on.

## Solution
* Grading job creation with file URLs, a grading script to be executed on a worker, queue information, and response information.
* New response route that saves the complete logs and output (if available) from Orca.
* Secret handling as a source of authentication to ensure no bogus files are created.