### PR TITLE
Fix: Race Condition on Test Deleting Upload Path

### DIFF
--- a/test/controllers/files_controller_test.rb
+++ b/test/controllers/files_controller_test.rb
@@ -9,14 +9,6 @@ class FilesControllerTest < ActionController::TestCase
     "resource": Rails.root.join("lib/assets")
   }
 
-  setup do
-    Upload.base_upload_dir.mkpath
-  end
-
-  teardown do
-    FileUtils.rmdir(Upload.base_upload_dir)
-  end
-
   test "should get valid file path" do
     @@method_to_dir.each do |method, dir|
       Tempfile.create("foo", dir) do |f|

--- a/test/controllers/files_controller_test.rb
+++ b/test/controllers/files_controller_test.rb
@@ -9,6 +9,12 @@ class FilesControllerTest < ActionController::TestCase
     "resource": Rails.root.join("lib/assets")
   }
 
+  setup do
+    unless File.directory? Upload.base_upload_dir
+      FileUtils.mkdir Upload.base_upload_dir
+    end
+  end
+
   test "should get valid file path" do
     @@method_to_dir.each do |method, dir|
       Tempfile.create("foo", dir) do |f|


### PR DESCRIPTION
When the `FilesController` test is not the first test to run, The `teardown` was attempting to remove the upload dir while files from the previous tests that utilized `Upload` populated that directory, thus causing a directory not empty error.