### PR TITLE
Feature: `status` Column on Graders to Indicate Orca Usage

### DIFF
--- a/app/controllers/api/graders_controller.rb
+++ b/app/controllers/api/graders_controller.rb
@@ -1,0 +1,38 @@
+module Api
+  class GradersController < ApiController
+    skip_before_action :doorkeeper_authorize!
+
+    def orca_response
+      begin
+        body = orca_response_params
+      rescue JSON::NestingError
+        return head :bad_request
+      end
+      grader_id = body[:build_key]['grader_id']
+      grader = Grader.find_by_id grader_id
+      return head :bad_request if grader.nil?
+      return head :bad_request unless grader.status['useOrca']
+
+      # TODO: Write this to the build_result.json file for the given grader.
+      build_status = body[:was_successful] ? 'Completed' : 'Failed'
+      logs = body[:logs]
+      grader.status = { **grader.status, 'logs' => logs, 'buildStatus' => build_status }
+      grader.save!
+      head :ok
+    end
+
+    private
+
+    def orca_response_params
+      build_key = JSON.parse(params.require(:build_key), {
+                               max_nesting: 1,
+                               create_additions: false
+                             })
+      {
+        build_key: build_key,
+        was_successful: params[:was_successful],
+        logs: params[:logs].map { |l| l.permit!.to_h }
+      }
+    end
+  end
+end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -183,6 +183,7 @@ class AssignmentsController < ApplicationController
     ap = assignment_params
     ap[:graders_attributes]&.each do |k, v|
       v[:upload_by_user_id] = current_user.id
+      v[:status] = { "useOrca": v[:status] == "1" }
     end
     ap[:course_id] = @course.id
     ap[:blame_id] = current_user.id
@@ -220,6 +221,7 @@ class AssignmentsController < ApplicationController
     # Assign the current user to all file uploads for grader configs
     ap[:graders_attributes]&.each do |k, v|
       v[:upload_by_user_id] = current_user.id
+      v[:status] = { "useOrca": v[:status] == "1" }
     end
     if ap[:prevent_late_submissions] == "1" # i.e., true
       ap[:prevent_late_submissions] = ap[:related_assignment_id]
@@ -287,7 +289,7 @@ class AssignmentsController < ApplicationController
                               type: "application/json", filename: "summary.json" }
     end
   end
-  
+
   def tarball
     tb = SubTarball.new(params[:id])
     if params[:moss]
@@ -387,7 +389,7 @@ class AssignmentsController < ApplicationController
                                  :type, :id, :_destroy, :errors_to_show, :test_class, :test_timeout,
                                  :review_target, :review_count, :review_threshold,
                                  :upload_by_user_id, :order, :line_length, :extra_credit,
-                                 :removefile
+                                 :removefile, :status
                                ]
                               )
   end

--- a/app/controllers/graders_controller.rb
+++ b/app/controllers/graders_controller.rb
@@ -1,0 +1,28 @@
+class GradersController < ApplicationController
+  before_action :find_course
+  before_action :find_assignment
+  before_action :find_grader
+
+  def build_log
+    unless @grader.status['useOrca']
+      return redirect_to course_assignment_path(@course, @assignment),
+                         alert: 'This grader does not use Orca'
+    end
+    @build_status = @grader.status['buildStatus']
+    if @build_status.nil? || @build_status == 'Pending'
+      return redirect_to course_assignment_path(@course, @assignment),
+                         alert: 'This grader is still being built'
+    end
+    @logs = @grader.status['logs']
+    render action: 'build_log'
+  end
+
+  private
+
+  def find_grader
+    @grader = Grader.find_by_id params[:id]
+    return unless @grader.nil?
+
+    redirect_to course_assignment_path(@course, @assignment), alert: 'No such grader'
+  end
+end

--- a/app/models/grader.rb
+++ b/app/models/grader.rb
@@ -114,19 +114,23 @@ class Grader < ApplicationRecord
   before_save :save_uploads
 
   include GradersHelper
-  
+
   class << self
     attr_accessor :delayed_grades
     attr_accessor :delayed_count
   end
   @delayed_grades = {}
   @delayed_count = 0
-  
+
   def self.delayed_grades
     @delayed_grades
   end
   def self.delayed_count
     @delayed_count
+  end
+
+  def self.orca_build_config_path
+    File.join(upload.extracted_path, 'orca-build-config.json')
   end
 
   # Needed because when Cocoon instantiates new graders, it doesn't know what
@@ -187,7 +191,7 @@ class Grader < ApplicationRecord
       0.0
     end
   end
-  
+
   def grade_sync!(assignment, submission)
     ans = do_grading(assignment, submission)
     submission.compute_grade! if submission.grade_complete?
@@ -325,7 +329,7 @@ class Grader < ApplicationRecord
     self.upload&.save!
     self.extra_upload&.save!
   end
-  
+
   def recompute_grades
     # nothing to do by default
   end
@@ -342,7 +346,7 @@ class Grader < ApplicationRecord
     end
     g
   end
- 
+
   def is_int(v)
     Integer(v) rescue false
   end

--- a/app/views/graders/_junit_grader.html.erb
+++ b/app/views/graders/_junit_grader.html.erb
@@ -47,4 +47,10 @@
     <td class="col-sm-4"><%= f.spinner "errors_to_show", errs, min: 0, delta: 1 %></td>
     <td></td>
   </tr>
+  <tr class="form-group">
+    <td><%= f.label "status", "Use Orca?" %></td>
+    <td><%= f.check_box :status, checked: f.object.status.dig("useOrca"),
+      data: {toggle: "toggle", on: "Yes", off: "No"} %></td>
+    <td></td>
+  </tr>
 </table>

--- a/app/views/graders/_junit_grader.html.erb
+++ b/app/views/graders/_junit_grader.html.erb
@@ -48,7 +48,7 @@
     <td></td>
   </tr>
   <tr class="form-group">
-    <td><%= f.label "status", "Use Orca?" %></td>
+    <td class="col-sm-4"><%= f.label "status", "Use Orca? (Experimental: do not use yet!)" %></td>
     <td><%= f.check_box :status, checked: f.object.status.dig("useOrca"),
       data: {toggle: "toggle", on: "Yes", off: "No"} %></td>
     <td></td>
@@ -67,7 +67,7 @@
         <td class="text-warning">Pending</td>
       <% end %>
       <% unless f.object.status.dig("logs").nil? %>
-        <td>Build Logs</td>
+        <td><%= link_to "Build Logs", build_log_course_assignment_grader_path(@course, @assignment, f.object) %></td>
       <% end %>
       <td></td>
     </tr>

--- a/app/views/graders/_junit_grader.html.erb
+++ b/app/views/graders/_junit_grader.html.erb
@@ -53,4 +53,23 @@
       data: {toggle: "toggle", on: "Yes", off: "No"} %></td>
     <td></td>
   </tr>
+  <%# TODO: connect to the Orca "source of truth" for if the image exists.%>
+  <% if f.object.status.dig("useOrca") && !f.object.status.dig("buildStatus").nil? %>
+    <% build_status = f.object.status.dig("buildStatus") %>
+    <tr>
+      <td><strong>Orca Grader Build</strong></td>
+      <%# TODO: link to detailed output logs from Orca %>
+      <% if build_status == "Completed" %>
+        <td class="text-success">Completed</td>
+      <% elsif build_status == "Failed" %>
+        <td class="text-danger">Failed</td>
+      <% else %>
+        <td class="text-warning">Pending</td>
+      <% end %>
+      <% unless f.object.status.dig("logs").nil? %>
+        <td>Build Logs</td>
+      <% end %>
+      <td></td>
+    </tr>
+  <% end %>
 </table>

--- a/app/views/graders/build_log.html.erb
+++ b/app/views/graders/build_log.html.erb
@@ -1,0 +1,43 @@
+<!--
+  interface ImageBuildResult {
+    was_successful: boolean,
+    logs: Array<ImageBuildLog>
+  }
+
+  // NOTE: ImageBuildLogs should always have
+  // either an output property (X)OR an error property.
+  // When a build is successful, no logs will have error properties.
+  interface ImageBuildLog {
+    step: string,
+    output?: string,
+    error?: string
+  }
+-->
+<h3>Detailed Orca Build Logs</h3>
+<% if @build_status == "Completed" %>
+  <div class="alert alert-success">
+    <ul>
+    <% @logs.each do |log| %>
+      <li>
+        <h5><%= log["step"] %></h5>
+        <pre class="ouptut"><%= log["output"] %></pre>
+      </li>
+    <% end %>
+    </ul>
+  </div>
+<% else %>
+  <div class="alert alert-danger">
+    <ul>
+    <% @logs.each do |log| %>
+      <li>
+        <h5><%= log["step"] %></h5>
+        <% if log["output"] %>
+         <pre class="output"><%= log["output"] %></pre>
+        <% else %>
+         <pre class="output error"><%= log["error"] %></pre>
+        <% end %>
+      </li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/graders/build_log.html.erb
+++ b/app/views/graders/build_log.html.erb
@@ -14,30 +14,18 @@
   }
 -->
 <h3>Detailed Orca Build Logs</h3>
-<% if @build_status == "Completed" %>
-  <div class="alert alert-success">
-    <ul>
-    <% @logs.each do |log| %>
-      <li>
-        <h5><%= log["step"] %></h5>
-        <pre class="ouptut"><%= log["output"] %></pre>
-      </li>
-    <% end %>
-    </ul>
-  </div>
-<% else %>
-  <div class="alert alert-danger">
-    <ul>
-    <% @logs.each do |log| %>
-      <li>
-        <h5><%= log["step"] %></h5>
-        <% if log["output"] %>
-         <pre class="output"><%= log["output"] %></pre>
-        <% else %>
-         <pre class="output error"><%= log["error"] %></pre>
-        <% end %>
-      </li>
-    <% end %>
-    </ul>
-  </div>
-<% end %>
+<ol>
+  <% @logs.each do |log| %>
+    <li>
+      <% if log["error"] %>
+        <div class="alert alert-danger">
+          <h4><%= log["step"] %></h4>
+          <pre class="output error"><%= log["error"] %></pre>
+        </div>
+      <% else %>
+          <h4><%= log["step"] %></h4>
+          <pre class="output"><%= log["output"] %></pre>
+      <% end %>
+    </li>
+  <% end %>
+</ol>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,11 +15,11 @@ Rails.application.routes.draw do
         collection do
           post :create_or_update
         end
-        resources :graders do
-          collection do
-            post :orca_response
-          end
-        end
+      end
+    end
+    resources :graders do
+      collection do
+        post :orca_response
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,11 @@ Rails.application.routes.draw do
         collection do
           post :create_or_update
         end
+        resources :graders do
+          collection do
+            post :orca_response
+          end
+        end
       end
     end
   end
@@ -46,7 +51,7 @@ Rails.application.routes.draw do
 
   get 'files/*path', to: 'files#upload', constraints: {path: /.*/}
   get 'resources/*path', to: 'files#resource', constraints: {path: /.*/}
-  
+
   resources :terms
 
   resources :courses, except: [:destroy] do
@@ -62,7 +67,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :grading_conflicts do 
+    resources :grading_conflicts do
       member do
         post 'resubmit', to: 'grading_conflicts#resubmit_conflict_request', as: 'resubmit'
       end
@@ -147,9 +152,9 @@ Rails.application.routes.draw do
           post 'recreate/:grader_id', to: 'submissions#recreate_grade', as: 'recreate_grade'
           get 'plagiarism', to: 'submissions#edit_plagiarism', as: 'edit_plagiarism'
           patch 'plagiarism', to: 'submissions#update_plagiarism', as: 'update_plagiarism'
-          patch 'split', to: 'submissions#split_submission', as: 'split'          
+          patch 'split', to: 'submissions#split_submission', as: 'split'
         end
-        resources :reviews, only: [:show] 
+        resources :reviews, only: [:show]
         resources :grades, only: [:show, :edit, :update] do
           member do
             post :regrade

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,7 @@ Rails.application.routes.draw do
       end
       resources :graders, only: [] do
         member do
+          get 'build_log' => 'graders#build_log'
           get 'all_grades' => 'grades#tarball'
           get 'bulk' => 'grades#bulk_edit'
           post 'bulk' => 'grades#bulk_update'

--- a/db/migrate/20240713155148_add_grader_column_status.rb
+++ b/db/migrate/20240713155148_add_grader_column_status.rb
@@ -1,0 +1,5 @@
+class AddGraderColumnStatus < ActiveRecord::Migration[7.0]
+  def change
+    add_column :graders, :status, :json, default: { useOrca: false }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_26_161610) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_13_155148) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -93,6 +93,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_26_161610) do
     t.integer "assignment_id", null: false
     t.integer "extra_upload_id"
     t.boolean "extra_credit", default: false, null: false
+    t.json "status", default: {"useOrca"=>false}
   end
 
   create_table "grades", force: :cascade do |t|


### PR DESCRIPTION
### Description
Once Orca results can be rendered in the UI, we need a way to store image build information about the Graders as well as know if we should render this information on Bottlenose. This can be accomplished by having a JSON field on Graders in the DB, detailing if the grader is using Orca and what the status of its image build is on the Orca web server.

### Changes Made
* Migration to add `status` column to the Graders table.
    * Default value of `{ useOrca: false }`, as currently using Orca is not assumed by graders.
* `schema.rb` updated to reflect changes.