### PR TITLE
chore: add orca production doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,4 +196,4 @@ ensure that the Site URL is filled in, and click Save Settings.
 To connect Bottlenose to the [Orca](https://github.com/CodeGrade/orca) grading service, two values need to be set:
 
 1. Orca's Web API URL should be added to `config/orca.yml` under `site_url` -> `production` (see development url in that file for example).
-2. After generating an API key with Orca, that key value should be pasted into `Orca API Key` when visiting Bottlenose's 'Settings' page.
+2. After generating an API key with Orca, that key value should be pasted into `Orca API Key` when visiting Bottlenose's 'Settings' page. The hostname given to Orca during API key generation should match the `site_url` setting for Bottlenose.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ of programming assignments.
 
 Bottlenose is built expecting the following environment:
 
- * Ubuntu 16.04 
+ * Ubuntu 16.04
  * A BTRFS (or ZFS) filesystem for at least /var (although a btrfs root is easiest)
  * PostgreSQL
  * Ruby + Bundler
@@ -190,3 +190,10 @@ and you can start or restart the background graders with
 ```
 Once the server has been started, go to the Settings > Edit page,
 ensure that the Site URL is filled in, and click Save Settings.
+
+### Utilization with Orca (Production)
+
+To connect Bottlenose to the [Orca](https://github.com/CodeGrade/orca) grading service, two values need to be set:
+
+1. Orca's Web API URL should be added to `config/orca.yml` under `site_url` -> `production` (see development url in that file for example).
+2. After generating an API key with Orca, that key value should be pasted into `Orca API Key` when visiting Bottlenose's 'Settings' page.


### PR DESCRIPTION
Users (especially those deploying Bottlenose) should know how to connect the service to Orca.

Notes about setting the site URL value and API key added to the README file.