### PR TITLE
Fix: Accidentally added `timed_out` field to grading job result.

### DIFF
--- a/app/controllers/api/grades_controller.rb
+++ b/app/controllers/api/grades_controller.rb
@@ -75,7 +75,7 @@ module Api
           {
             **shell_response_hash,
             status_code: shell_response_hash[:status_code].to_i,
-            timed_out: shell_response_hash[:timed_out] == 'true'
+            did_timeout: shell_response_hash[:did_timeout] == 'true'
           }
         end
         errors = params[:errors] || []

--- a/test/controllers/api/grades_controller_test.rb
+++ b/test/controllers/api/grades_controller_test.rb
@@ -54,7 +54,7 @@ module Api
           stdout: 'TAP output.',
           stderr: '',
           status_code: 0,
-          timed_out: false,
+          did_timeout: false,
           cmd: ['echo', '"TAP output."']
         }],
         errors: []


### PR DESCRIPTION
Accidentally pushed up a field for `timed_out` when processing the grading job result from Orca in the Grades API controller.

This now processes the correct field, `did_timeout`.